### PR TITLE
docs: add migration guide from v0.1 to v0.2

### DIFF
--- a/crates/stellation/src/guides/migration_01_02.rs
+++ b/crates/stellation/src/guides/migration_01_02.rs
@@ -5,8 +5,8 @@
 //! `stellation-backend` has been separated into multiple crates:
 //!
 //! 1. `stellation-backend`: contains server renderer and other utilities to build backends.
-//! 2. `stellation-backend-warp`: contains server that can be converted into a warp filter.
-//! 3. `stellation-backend-tower`: contains server that can be converted into a tower service.
+//! 2. `stellation-backend-warp`: contains server that can be used as a warp filter.
+//! 3. `stellation-backend-tower`: contains server that can be used as a tower service.
 //! 4. `stellation-backend-cli`: contain out-of-the-box command line utility for backend
 //!    applications.
 //!

--- a/crates/stellation/src/guides/migration_01_02.rs
+++ b/crates/stellation/src/guides/migration_01_02.rs
@@ -1,0 +1,21 @@
+//! Migration Guide from v0.1 to v0.2
+//!
+//! # 1. `stellation-backend` crate has been separated into multiple crates.
+//!
+//! `stellation-backend` has been separated into multiple crates:
+//!
+//! 1. `stellation-backend`: contains server renderer and other utilities to build backends.
+//! 2. `stellation-backend-warp`: contains server that can be converted into a warp filter.
+//! 3. `stellation-backend-tower`: contains server that can be converted into a tower service.
+//! 4. `stellation-backend-cli`: contain out-of-the-box command line utility for backend
+//!    applications.
+//!
+//! # 2. `stellation-bridge` has been rewritten.
+//!
+//! Previously, it uses feature flags to switch between local and remote bridges.
+//! This has been switched to a link based system.
+//!
+//! Since this is a complete rewrite, we recommend users to refer to the new [fullstack](https://github.com/futursolo/stellation/tree/main/examples/fullstack) example about
+//! how to use the new bridge.
+//!
+//! # 3. Bounce is updated to version v0.7

--- a/crates/stellation/src/guides/mod.rs
+++ b/crates/stellation/src/guides/mod.rs
@@ -4,6 +4,6 @@
 //!
 //! # Migration Guides
 //!
-//! 1. [`v0.1 to v0.2`](migration_01_02)
+//! 1. [v0.1 to v0.2](migration_01_02)
 
 pub mod migration_01_02;

--- a/crates/stellation/src/guides/mod.rs
+++ b/crates/stellation/src/guides/mod.rs
@@ -1,0 +1,9 @@
+//! Guides and Tutorials
+//!
+//! This module contains various guides and tutorials for stellation.
+//!
+//! # Migration Guides
+//!
+//! 1. [`v0.1 to v0.2`](migration_01_02)
+
+pub mod migration_01_02;

--- a/crates/stellation/src/lib.rs
+++ b/crates/stellation/src/lib.rs
@@ -15,3 +15,5 @@
 //!   frontend and backend.
 //! 4. [stctl]: Command line utility for building and serving development
 //! server.
+
+pub mod guides;


### PR DESCRIPTION
Fix: #68 